### PR TITLE
Use wasm-pack-npm to install rust and wasm-pack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ node_js:
 
 before_install:
   - export PATH="$HOME/.cargo/bin:$PATH"
-  - command -v rustup || curl https://sh.rustup.rs -sSf | sh -s -- -y
-  - rustup default stable
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - export PATH="$HOME/.cargo/bin:$PATH"
 
 before_script:
-  - rustup default nightly
+  - rustup default stable
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ node_js:
 before_install:
   - export PATH="$HOME/.cargo/bin:$PATH"
 
+before_script:
+  - rustup default nightly
+
 cache:
   directories:
     - $TRAVIS_BUILD_DIR/target

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,3 @@ cache:
     - $TRAVIS_BUILD_DIR/node_modules
     - $HOME/.cargo
     - $HOME/.npm
-

--- a/build.ts
+++ b/build.ts
@@ -55,16 +55,6 @@ const execCommand = (command: string, cwd = '') => new Promise(
   }
 );
 
-async function installWasmPack() {
-  try {
-    // Check whether wasm-pack is available
-    await execCommand('wasm-pack --version');
-  } catch {
-    // If not, install it
-    await execCommand('cargo install wasm-pack');
-  }
-}
-
 async function wasmPack() {
   await execCommand(`wasm-pack build --target nodejs --out-dir ${WASM_PACK_DEST}`);
 }
@@ -148,7 +138,6 @@ function bundle() {
 }
 
 export const build = series(
-  installWasmPack,
   clean,
   wasmPack,
   inlineWasm,

--- a/package-lock.json
+++ b/package-lock.json
@@ -415,6 +415,15 @@
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
     "ansi-wrap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
@@ -994,6 +1003,17 @@
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
       "dev": true
     },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
     "chokidar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
@@ -1128,6 +1148,21 @@
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
       }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "color-support": {
       "version": "1.1.3",
@@ -2690,6 +2725,12 @@
       "requires": {
         "glogg": "^1.0.0"
       }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -4373,6 +4414,17 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -4693,6 +4745,15 @@
       "dev": true,
       "requires": {
         "is-utf8": "^0.2.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
       }
     },
     "sver-compat": {
@@ -5188,6 +5249,16 @@
       "dev": true,
       "requires": {
         "indexof": "0.0.1"
+      }
+    },
+    "wasm-pack-npm": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/wasm-pack-npm/-/wasm-pack-npm-0.1.3.tgz",
+      "integrity": "sha512-2cFmDQ31PXM7sevKrITpUpdMgJiifDJrYPO6dL7evendsf75SzzxcBt5hndVXwXsc+cubQF3fXhry+4vLGPwwQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "shelljs": "^0.8.2"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "terser-webpack-plugin": "^1.2.3",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.3",
+    "wasm-pack-npm": "^0.1.3",
     "webpack": "^4.30.0"
   },
   "dependencies": {


### PR DESCRIPTION
This uses [wasm-pack-npm](https://github.com/robertohuertasm/wasm-pack-npm) to install rust and wasm-pack. This way the CI build can be simplified.